### PR TITLE
Update functions.ps1

### DIFF
--- a/task/functions.ps1
+++ b/task/functions.ps1
@@ -84,11 +84,11 @@ Function Get-Encoding
     switch ($Name)
     {
         "Ascii" { return New-Object System.Text.ASCIIEncoding }
-        "UTF7" { return New-Object System.Text.UTF7Encoding($WriteBOM) }
-        "UTF8" { return New-Object System.Text.UTF8Encoding($WriteBOM) }
-        "Unicode" { return New-Object System.Text.UnicodeEncoding($WriteBOM) }
+        "UTF7" { return New-Object System.Text.UTF7Encoding($false, $WriteBOM) }
+        "UTF8" { return New-Object System.Text.UTF8Encoding($false, $WriteBOM) }
+        "Unicode" { return New-Object System.Text.UnicodeEncoding($false, $WriteBOM) }
         "BigEndianUnicode" { return New-Object System.Text.UnicodeEncoding($true, $WriteBOM) }
-        "UTF32" { return New-Object System.Text.UTF32Encoding($WriteBOM) }
+        "UTF32" { return New-Object System.Text.UTF32Encoding($false, $WriteBOM) }
         "BigEndianUTF32" { return New-Object System.Text.UTF32Encoding($true, $WriteBOM) }
     }
 }

--- a/task/functions.ps1
+++ b/task/functions.ps1
@@ -84,8 +84,8 @@ Function Get-Encoding
     switch ($Name)
     {
         "Ascii" { return New-Object System.Text.ASCIIEncoding }
-        "UTF7" { return New-Object System.Text.UTF7Encoding($false, $WriteBOM) }
-        "UTF8" { return New-Object System.Text.UTF8Encoding($false, $WriteBOM) }
+        "UTF7" { return New-Object System.Text.UTF7Encoding() }
+        "UTF8" { return New-Object System.Text.UTF8Encoding($WriteBOM) }
         "Unicode" { return New-Object System.Text.UnicodeEncoding($false, $WriteBOM) }
         "BigEndianUnicode" { return New-Object System.Text.UnicodeEncoding($true, $WriteBOM) }
         "UTF32" { return New-Object System.Text.UTF32Encoding($false, $WriteBOM) }


### PR DESCRIPTION
Fixed a problem where the constructors of the Encoding classes of System.Text were being incorrectly called with one argument when the classes have no constructors that accept only one parameter.