### PR TITLE
Add option for XML escaping and JSON encoding variable values before token replacement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Parameters include:
 - **Token prefix**: the prefix of the tokens to search in the target files.
 - **Token suffix**: the suffix of the tokens to search in the target files.
 - **Empty value**: the variable value that will be replaced with an empty string.
-- **Escape character**: the escape character to use when escaping characters in the variable values.
-- **Characters to escape**: characters in variable values to escape before replacing tokens.
+- **Escape type**: specify how to escape variable values.
+- **Escape character**: when using custom escape type, the escape character to use when escaping characters in the variable values.
+- **Characters to escape**: when using custom escape type, characters in variable values to escape before replacing tokens.
 
 ## Tips
 If you want to use tokens in XML based configuration files to be replaced during deployment and also have those files usable for local development you can combine the [Replace Tokens task](https://marketplace.visualstudio.com/items?itemName=qetza.replacetokens) with the [XDT tranform task](https://marketplace.visualstudio.com/items?itemName=qetza.xdttransform):

--- a/task/index.ts
+++ b/task/index.ts
@@ -150,6 +150,11 @@ var replaceTokensInFile = function (
 }
 
 var escapeXml = function (unsafe: string): string {
+    // Don't double-escape if existing XML escaping is detected.
+    if(unsafe.indexOf('&lt;') || unsafe.indexOf('&gt;') || unsafe.indexOf('&amp;') || unsafe.indexOf('&apos;') || unsafe.indexOf('&quot;')) {       
+       return unsafe;
+    }
+
     return unsafe.replace(/[<>&'"]/g, function (c) {
         switch (c) {
             case '<': return '&lt;';

--- a/task/index.ts
+++ b/task/index.ts
@@ -17,6 +17,17 @@ const ACTION_FAIL: string = 'fail';
 const XML_ESCAPE: RegExp = /[<>&'"]/g;
 const JSON_ESCAPE: RegExp = /["\\/\b\f\n\r\t]/g;
 
+interface Options {
+    readonly encoding: string, 
+    readonly keepToken: boolean,
+    readonly actionOnMissing: string, 
+    readonly writeBOM: boolean, 
+    readonly emptyValue: string, 
+    readonly escapeType: string,
+    readonly escapeChar: string, 
+    readonly charsToEscape: string
+}
+
 var mapEncoding = function (encoding: string): string {
     switch (encoding)
     {
@@ -87,19 +98,12 @@ var getEncoding = function (filePath: string): string {
 var replaceTokensInFile = function (
     filePath: string, 
     regex: RegExp, 
-    encoding: string, 
-    keepToken: boolean, 
-    actionOnMissing: string, 
-    writeBOM: boolean, 
-    emptyValue: string,
-    escapeChar: string,
-    charsToEscape: string,
-    escapeXml: boolean,
-    escapeJson: boolean): void {
+    options: Options): void {
     console.log('replacing tokens in: ' + filePath);
 
     // ensure encoding
-    if (encoding === ENCODING_AUTO)
+    let encoding: string = options.encoding;
+    if (options.encoding === ENCODING_AUTO)
         encoding = getEncoding(filePath);
 
     // read file and replace tokens
@@ -109,13 +113,13 @@ var replaceTokensInFile = function (
 
         if (!value)
         {
-            if (keepToken)
+            if (options.keepToken)
                 value = match;
             else
                 value = '';
 
             let message = 'variable not found: ' + name;
-            switch (actionOnMissing)
+            switch (options.actionOnMissing)
             {
                 case ACTION_WARN:
                     tl.warning(message);
@@ -129,63 +133,70 @@ var replaceTokensInFile = function (
                     tl.debug(message);
             }
         }
-        else if (emptyValue && value === emptyValue)
+        else if (options.emptyValue && value === options.emptyValue)
             value = '';
 
-        if (escapeChar && charsToEscape)
-            for (var c of charsToEscape)
-                // split and join to avoid regex and escaping escape char
-                value = value.split(c).join(escapeChar + c);
+        switch (options.escapeType) {
+            case 'json':
+                value = value.replace(JSON_ESCAPE, match => {
+                    switch (match) {
+                        case '"':
+                        case '\\':
+                        case '/':
+                            return '\\' + match;
+                        
+                        case '\b': return "\\b";
+                        case '\f': return "\\f";
+                        case '\n': return "\\n";
+                        case '\r': return "\\r";
+                        case '\t': return "\\t";
+                    }
+                });
+                break;
 
-        if (escapeJson)
-            value = value.replace(JSON_ESCAPE, match => {
-                switch (match) {
-                    case '"':
-                    case '\\':
-                    case '/':
-                        return '\\' + match;
-                    
-                    case '\b': return "\\b";
-                    case '\f': return "\\f";
-                    case '\n': return "\\n";
-                    case '\r': return "\\r";
-                    case '\t': return "\\t";
-                }
-            });
+            case 'xml':
+                value = value.replace(XML_ESCAPE, match => {
+                    switch (match) {
+                        case '<': return '&lt;';
+                        case '>': return '&gt;';
+                        case '&': return '&amp;';
+                        case '\'': return '&apos;';
+                        case '"': return '&quot;';
+                    }
+                });
+                break;
 
-        if (escapeXml)
-            value = value.replace(XML_ESCAPE, match => {
-                switch (match) {
-                    case '<': return '&lt;';
-                    case '>': return '&gt;';
-                    case '&': return '&amp;';
-                    case '\'': return '&apos;';
-                    case '"': return '&quot;';
-                }
-            });
+            case 'custom':
+                if (options.escapeChar && options.charsToEscape)
+                    for (var c of options.charsToEscape)
+                        // split and join to avoid regex and escaping escape char
+                        value = value.split(c).join(options.escapeChar + c);
+                break;
+        }
 
         return value;
     });
 
     // write file
-    fs.writeFileSync(filePath, iconv.encode(content, encoding, { addBOM: writeBOM, stripBOM: null, defaultEncoding: null }));
+    fs.writeFileSync(filePath, iconv.encode(content, encoding, { addBOM: options.writeBOM, stripBOM: null, defaultEncoding: null }));
 }
 
 async function run() {
     try {
         // load inputs
         let root: string = tl.getPathInput('rootDirectory', false, true);
-        let encoding: string = mapEncoding(tl.getInput('encoding', true));
         let tokenPrefix: string = tl.getInput('tokenPrefix', true).replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
         let tokenSuffix: string = tl.getInput('tokenSuffix', true).replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-        let keepToken: boolean = tl.getBoolInput('keepToken', true);
-        let actionOnMissing: string = tl.getInput('actionOnMissing', true);
-        let writeBOM: boolean = tl.getBoolInput('writeBOM', true);
-        let emptyValue: string = tl.getInput('emptyValue', false);
-        let escapeChar: string = tl.getInput('escapeChar', false);
-        let charsToEscape: string = tl.getInput('charsToEscape', false);
-        let escapeXml: boolean = tl.getBoolInput('xmlEscape', true);
-        let escapeJson: boolean = tl.getBoolInput('jsonEncode',true);
+        let options: Options = {
+            encoding: mapEncoding(tl.getInput('encoding', true)),
+            keepToken: tl.getBoolInput('keepToken', true),
+            actionOnMissing: tl.getInput('actionOnMissing', true),
+            writeBOM: tl.getBoolInput('writeBOM', true),
+            emptyValue: tl.getInput('emptyValue', false),
+            escapeType: tl.getInput('escapeType', false),
+            escapeChar: tl.getInput('escapeChar', false),
+            charsToEscape: tl.getInput('charsToEscape', false)
+        };
 
         let targetFiles: string[] = [];
         tl.getDelimitedInput('targetFiles', '\n', true).forEach((x: string) => {
@@ -209,7 +220,7 @@ async function run() {
                 return;
             }
 
-            replaceTokensInFile(filePath, regex, encoding, keepToken, actionOnMissing, writeBOM, emptyValue, escapeChar, charsToEscape, escapeXml, escapeJson);
+            replaceTokensInFile(filePath, regex, options);
         });
     }
     catch (err)

--- a/task/task.json
+++ b/task/task.json
@@ -12,7 +12,7 @@
     "author": "Guillaume Rouchon",
     "version": {
         "Major": 2,
-        "Minor": 3,
+        "Minor": 4,
         "Patch": 0
     },
     "minimumAgentVersion": "2.105.0",
@@ -133,6 +133,15 @@
             "label": "Characters to escape",
             "groupName": "advanced",
             "helpMarkDown": "Characters in variable values to escape before replacing tokens."
+        },
+        {
+            "name": "xmlEscape",
+            "type": "boolean",
+            "label": "XML escape",
+            "groupName": "advanced",
+            "defaultValue": "false",
+            "required": "true",
+            "helpMarkDown": "XML escape variable values before replacing tokens."
         }
     ],
     "instanceNameFormat": "Replace tokens in $(targetFiles)",

--- a/task/task.json
+++ b/task/task.json
@@ -121,10 +121,25 @@
             "helpMarkDown": "The variable value which will be replaced by an empty string."
         },
         {
+            "name": "escapeType",
+            "type": "pickList",
+            "defaultValue": "none",
+            "label": "Escape values type",
+            "groupName": "advanced",
+            "helpMarkDown": "Specify how to escape variable values.",
+            "options": {
+                "none": "no escaping",
+                "json": "json",
+                "xml": "xml",
+                "custom": "custom" 
+            }
+        },
+        {
             "name": "escapeChar",
             "type": "string",
             "label": "Escape character",
             "groupName": "advanced",
+            "visibleRule": "escapeType = custom",
             "helpMarkDown": "The escape character to use when escaping characters in the variable values."
         },
         {
@@ -132,25 +147,8 @@
             "type": "string",
             "label": "Characters to escape",
             "groupName": "advanced",
+            "visibleRule": "escapeType = custom",
             "helpMarkDown": "Characters in variable values to escape before replacing tokens."
-        },
-        {
-            "name": "jsonEncode",
-            "type": "boolean",
-            "label": "JSON encode",
-            "groupName": "advanced",
-            "defaultValue": "false",
-            "required": "true",
-            "helpMarkDown": "JSON encode variable values before replacing tokens.<br/>When multiple escaping methods are selected, they are applied in the order listed here."
-        },
-        {
-            "name": "xmlEscape",
-            "type": "boolean",
-            "label": "XML escape",
-            "groupName": "advanced",
-            "defaultValue": "false",
-            "required": "true",
-            "helpMarkDown": "XML escape variable values before replacing tokens. Will not double escape if existing escaping is detected.<br/>When multiple escaping methods are selected, they are applied in the order listed here."
         }
     ],
     "instanceNameFormat": "Replace tokens in $(targetFiles)",

--- a/task/task.json
+++ b/task/task.json
@@ -12,8 +12,8 @@
     "author": "Guillaume Rouchon",
     "version": {
         "Major": 2,
-        "Minor": 4,
-        "Patch": 1
+        "Minor": 3,
+        "Patch": 0
     },
     "minimumAgentVersion": "2.105.0",
     "groups": [

--- a/task/task.json
+++ b/task/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 4,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "2.105.0",
     "groups": [

--- a/task/task.json
+++ b/task/task.json
@@ -135,13 +135,22 @@
             "helpMarkDown": "Characters in variable values to escape before replacing tokens."
         },
         {
+            "name": "jsonEncode",
+            "type": "boolean",
+            "label": "JSON encode",
+            "groupName": "advanced",
+            "defaultValue": "false",
+            "required": "true",
+            "helpMarkDown": "JSON encode variable values before replacing tokens.<br/>When multiple escaping methods are selected, they are applied in the order listed here."
+        },
+        {
             "name": "xmlEscape",
             "type": "boolean",
             "label": "XML escape",
             "groupName": "advanced",
             "defaultValue": "false",
             "required": "true",
-            "helpMarkDown": "XML escape variable values before replacing tokens."
+            "helpMarkDown": "XML escape variable values before replacing tokens.<br/>When multiple escaping methods are selected, they are applied in the order listed here."
         }
     ],
     "instanceNameFormat": "Replace tokens in $(targetFiles)",

--- a/task/task.json
+++ b/task/task.json
@@ -150,7 +150,7 @@
             "groupName": "advanced",
             "defaultValue": "false",
             "required": "true",
-            "helpMarkDown": "XML escape variable values before replacing tokens.<br/>When multiple escaping methods are selected, they are applied in the order listed here."
+            "helpMarkDown": "XML escape variable values before replacing tokens. Will not double escape if existing escaping is detected.<br/>When multiple escaping methods are selected, they are applied in the order listed here."
         }
     ],
     "instanceNameFormat": "Replace tokens in $(targetFiles)",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "replacetokens",
     "name": "Replace Tokens",
-    "version": "2.4.1",
+    "version": "2.3.0",
     "public": true,
     "publisher": "qetza",
     "targets": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "replacetokens",
     "name": "Replace Tokens",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "public": true,
     "publisher": "qetza",
     "targets": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "replacetokens",
     "name": "Replace Tokens",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "public": true,
     "publisher": "qetza",
     "targets": [


### PR DESCRIPTION
Adds a checkbox option to enable XML escaping of variable values before token replacement to the task. Useful for token replacement in XML configuration files where you may not want to use XML transformation.

Update; added JSON encoding of variable values. The sequence of operations where multiples are specified is: specified escape character, JSON encode, XML escape. This is explained in the helpMarkup.