### PR TITLE
Fix help markdown links

### DIFF
--- a/tasks/ReplaceTokensV3/task.json
+++ b/tasks/ReplaceTokensV3/task.json
@@ -3,7 +3,7 @@
     "name": "replacetokens",
     "friendlyName": "Replace Tokens",
     "description": "Replace tokens in files",
-    "helpMarkDown": "[Learn more about this task](https://github.com/qetza/vsts-replacetokens-task/blob/master/ReplaceTokens/ReplaceTokensV3/README.md)",
+    "helpMarkDown": "[Learn more about this task](https://github.com/qetza/vsts-replacetokens-task/blob/master/tasks/ReplaceTokensV3/README.md)",
     "category": "Utility",
     "visibility": [
         "Build",

--- a/tasks/ReplaceTokensV4/task.json
+++ b/tasks/ReplaceTokensV4/task.json
@@ -3,7 +3,7 @@
     "name": "replacetokens",
     "friendlyName": "Replace Tokens",
     "description": "Replace tokens in files",
-    "helpMarkDown": "[Learn more about this task](https://github.com/qetza/vsts-replacetokens-task/blob/master/ReplaceTokens/ReplaceTokensV4/README.md)",
+    "helpMarkDown": "[Learn more about this task](https://github.com/qetza/vsts-replacetokens-task/blob/master/tasks/ReplaceTokensV4/README.md)",
     "category": "Utility",
     "visibility": [
         "Build",

--- a/tasks/ReplaceTokensV5/task.json
+++ b/tasks/ReplaceTokensV5/task.json
@@ -3,7 +3,7 @@
     "name": "replacetokens",
     "friendlyName": "Replace Tokens",
     "description": "Replace tokens in files",
-    "helpMarkDown": "[Learn more about this task](https://github.com/qetza/vsts-replacetokens-task/blob/master/ReplaceTokens/ReplaceTokensV4/README.md)",
+    "helpMarkDown": "[Learn more about this task](https://github.com/qetza/vsts-replacetokens-task/blob/master/tasks/ReplaceTokensV5/README.md)",
     "category": "Utility",
     "visibility": [
         "Build",


### PR DESCRIPTION
"Learn more about this task" link in VSTS/Azure Dev Ops is incorrect and leads to a 404. This pull request attempts to correct the links.