### PR TITLE
Fixed the concatenation of names in the recursive replace tokens call

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ If you want to use tokens in XML based configuration files to be replaced during
   - replace tokens in your updated configuration file
 
 ## Release notes
+**New in 4.5.0**
+- Task **5.2.0**
+  - Fix recursion cycle detection ([#308](https://github.com/qetza/vsts-replacetokens-task/issues/308)) (contributed by Chad Smith).
+- Task **4.3.0**
+  - Fix recursion cycle detection ([#308](https://github.com/qetza/vsts-replacetokens-task/issues/308)) (contributed by Chad Smith).
+- Task **3.11.0**
+  - Fix recursion cycle detection ([#308](https://github.com/qetza/vsts-replacetokens-task/issues/308)) (contributed by Chad Smith).
+
 **New in 4.4.1**
 - Task **4.2.1**
   - Fix compatibility with node 5.10.1 ([#277](https://github.com/qetza/vsts-replacetokens-task/issues/277)).

--- a/tasks/ReplaceTokensV3/README.md
+++ b/tasks/ReplaceTokensV3/README.md
@@ -84,6 +84,9 @@ If you want to use tokens in XML based configuration files to be replaced during
   - replace tokens in your updated configuration file
 
 ## Release notes
+**New in 3.11.0**
+- Fix recursion cycle detection ([#308](https://github.com/qetza/vsts-replacetokens-task/issues/308)) (contributed by Chad Smith).
+
 **New in 3.10.1**
 - Fix compatibility with node 5.10.1 ([#277](https://github.com/qetza/vsts-replacetokens-task/issues/277)).
 

--- a/tasks/ReplaceTokensV3/index.ts
+++ b/tasks/ReplaceTokensV3/index.ts
@@ -321,7 +321,7 @@ var replaceTokensInString = function (
 
             // apply recursion on non-empty value (never apply escape)
             if (value && options.enableRecursion)
-                value = replaceTokensInString(value, regex, transformRegex, options, false, escapeType, counter, names + name);
+                value = replaceTokensInString(value, regex, transformRegex, options, false, escapeType, counter, names.concat(name));
 
             // apply transformation
             if (transformName)

--- a/tasks/ReplaceTokensV3/task.json
+++ b/tasks/ReplaceTokensV3/task.json
@@ -12,8 +12,8 @@
     "author": "Guillaume Rouchon",
     "version": {
         "Major": 3,
-        "Minor": 10,
-        "Patch": 1
+        "Minor": 11,
+        "Patch": 0
     },
     "instanceNameFormat": "Replace tokens in $(targetFiles)",
     "minimumAgentVersion": "2.105.0",

--- a/tasks/ReplaceTokensV3/tests/recursion/L0_Recursion.ts
+++ b/tasks/ReplaceTokensV3/tests/recursion/L0_Recursion.ts
@@ -6,8 +6,9 @@ const taskPath = path.join(__dirname, '..', '..', 'index.js');
 const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
 // variables
+process.env['var'] = 'var1';
 process.env['var1'] = '#{var2}#_#{var3}#';
-process.env['var2'] = 'var1';
+process.env['var2'] = '#{var}#';
 process.env['var3'] = 'value';
 
 // inputs

--- a/tasks/ReplaceTokensV4/README.md
+++ b/tasks/ReplaceTokensV4/README.md
@@ -93,6 +93,9 @@ If you want to use tokens in XML based configuration files to be replaced during
   - replace tokens in your updated configuration file
 
 ## Release notes
+**New in 4.3.0**
+- Fix recursion cycle detection ([#308](https://github.com/qetza/vsts-replacetokens-task/issues/308)) (contributed by Chad Smith).
+
 **New in 4.2.1**
 - Fix compatibility with node 5.10.1 ([#277](https://github.com/qetza/vsts-replacetokens-task/issues/277)).
 

--- a/tasks/ReplaceTokensV4/index.ts
+++ b/tasks/ReplaceTokensV4/index.ts
@@ -321,7 +321,7 @@ var replaceTokensInString = function (
 
             // apply recursion on non-empty value (never apply escape)
             if (value && options.enableRecursion)
-                value = replaceTokensInString(value, regex, transformRegex, options, false, escapeType, counter, names + name);
+                value = replaceTokensInString(value, regex, transformRegex, options, false, escapeType, counter, names.concat(name));
 
             // apply transformation
             if (transformName)

--- a/tasks/ReplaceTokensV4/task.json
+++ b/tasks/ReplaceTokensV4/task.json
@@ -12,8 +12,8 @@
     "author": "Guillaume Rouchon",
     "version": {
         "Major": 4,
-        "Minor": 2,
-        "Patch": 1
+        "Minor": 3,
+        "Patch": 0
     },
     "releaseNotes": "Added output variables (breaking change).<br/>Added token pattern dropdown (breaking change).",
     "instanceNameFormat": "Replace tokens in $(targetFiles)",

--- a/tasks/ReplaceTokensV4/tests/recursion/L0_Recursion.ts
+++ b/tasks/ReplaceTokensV4/tests/recursion/L0_Recursion.ts
@@ -6,8 +6,9 @@ const taskPath = path.join(__dirname, '..', '..', 'index.js');
 const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
 // variables
+process.env['var'] = 'var1';
 process.env['var1'] = '#{var2}#_#{var3}#';
-process.env['var2'] = 'var1';
+process.env['var2'] = '#{var}#';
 process.env['var3'] = 'value';
 
 // inputs

--- a/tasks/ReplaceTokensV5/README.md
+++ b/tasks/ReplaceTokensV5/README.md
@@ -93,6 +93,9 @@ If you want to use tokens in XML based configuration files to be replaced during
   - replace tokens in your updated configuration file
 
 ## Release notes
+**New in 5.2.0**
+- Fix recursion cycle detection ([#308](https://github.com/qetza/vsts-replacetokens-task/issues/308)) (contributed by Chad Smith).
+
 **New in 5.1.0**
 - Add support for inline variables ([#252](https://github.com/qetza/vsts-replacetokens-task/issues/252)).
 - Add support for recursive token replacement in values ([#201](https://github.com/qetza/vsts-replacetokens-task/issues/201)).

--- a/tasks/ReplaceTokensV5/index.ts
+++ b/tasks/ReplaceTokensV5/index.ts
@@ -320,7 +320,7 @@ var replaceTokensInString = function (
 
             // apply recursion on non-empty value (never apply escape)
             if (value && options.enableRecursion)
-                value = replaceTokensInString(value, regex, transformRegex, options, false, escapeType, counter, names + name);
+                value = replaceTokensInString(value, regex, transformRegex, options, false, escapeType, counter, names.concat(name));
 
             // apply transformation
             if (transformName)

--- a/tasks/ReplaceTokensV5/task.json
+++ b/tasks/ReplaceTokensV5/task.json
@@ -12,7 +12,7 @@
     "author": "Guillaume Rouchon",
     "version": {
         "Major": 5,
-        "Minor": 1,
+        "Minor": 2,
         "Patch": 0
     },
     "releaseNotes": "Migrate to Node10 handler (breaking change).",

--- a/tasks/ReplaceTokensV5/tests/recursion/L0_Recursion.ts
+++ b/tasks/ReplaceTokensV5/tests/recursion/L0_Recursion.ts
@@ -6,8 +6,9 @@ const taskPath = path.join(__dirname, '..', '..', 'index.js');
 const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
 // variables
+process.env['var'] = 'var1';
 process.env['var1'] = '#{var2}#_#{var3}#';
-process.env['var2'] = 'var1';
+process.env['var2'] = '#{var}#';
 process.env['var3'] = 'value';
 
 // inputs

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "replacetokens",
   "name": "Replace Tokens",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "public": true,
   "publisher": "qetza",
   "targets": [


### PR DESCRIPTION
Fixes #308

The first time this line of code runs it causes string concat (via coercion) of `[]` and a string, resulting in a string (thanks Javascript). 

This string is then passed back into the method and is concatenated with the next value, the intended result might be `['a', 'b', 'c']`, but this but causes the names value to instead contain `'abc'`.

The final nefarious actor in this scenario is the usage of `names.includes()` on line 273, which is shared by both Array and String. Using the example above checking for the presence of `'b'` would succeed in a string `'abc'` and not in the array of `['a', 'b', 'c']`.

I'm curious why Typescript didn't save the day by preventing the recursive call. When the string coercion/concat happens, the method should reject this parameter as it's not compatible with `string[]`